### PR TITLE
Change the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
+_Note that this project depends on internal Symphony infrastructure (repository.symphony.com), and therefore it can only be built by Symphony LLC employees/partners._
+
 # App-Integrations-Zapier
 Zapier Integration


### PR DESCRIPTION
Add a clear note at the top of each README.md file, so that you'll avoid a potential consumer/contributor to get a build failure.