### PR TITLE
APP-1017 Zapier with MessageML V2: empty message is rendered

### DIFF
--- a/src/main/java/org/symphonyoss/integration/webhook/zapier/parser/ZapierParserException.java
+++ b/src/main/java/org/symphonyoss/integration/webhook/zapier/parser/ZapierParserException.java
@@ -25,7 +25,7 @@ import org.symphonyoss.integration.webhook.exception.WebHookParseException;
  */
 public class ZapierParserException extends WebHookParseException {
 
-  private static final String COMPONENT = "Trello Webhook Dispatcher";
+  private static final String COMPONENT = "Zapier Webhook Dispatcher";
 
   /**
    * A Zapier exception.

--- a/src/main/java/org/symphonyoss/integration/webhook/zapier/parser/v2/V2ZapierPostMessageParser.java
+++ b/src/main/java/org/symphonyoss/integration/webhook/zapier/parser/v2/V2ZapierPostMessageParser.java
@@ -3,6 +3,7 @@ package org.symphonyoss.integration.webhook.zapier.parser.v2;
 import static org.symphonyoss.integration.parser.ParserUtils.MESSAGEML_LINEBREAK;
 import static org.symphonyoss.integration.webhook.zapier.ZapierEntityConstants.ACTION_FIELDS;
 import static org.symphonyoss.integration.webhook.zapier.ZapierEntityConstants.MESSAGE_CONTENT;
+import static org.symphonyoss.integration.webhook.zapier.ZapierEntityConstants.MESSAGE_HEADER;
 import static org.symphonyoss.integration.webhook.zapier.ZapierEventConstants.POST_MESSAGE;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -14,7 +15,6 @@ import org.symphonyoss.integration.model.message.Message;
 import org.symphonyoss.integration.webhook.WebHookPayload;
 import org.symphonyoss.integration.webhook.exception.WebHookParseException;
 import org.symphonyoss.integration.webhook.parser.WebHookParser;
-import org.symphonyoss.integration.webhook.parser.metadata.EntityObject;
 import org.symphonyoss.integration.webhook.parser.metadata.MetadataParser;
 import org.symphonyoss.integration.webhook.zapier.parser.ZapierParserException;
 
@@ -78,7 +78,13 @@ public class V2ZapierPostMessageParser extends MetadataParser implements WebHook
   protected void preProcessInputData(JsonNode input) {
     JsonNode actionNode = input.path(ACTION_FIELDS);
 
+    String messageHeader = actionNode.path(MESSAGE_HEADER).asText(StringUtils.EMPTY);
     String messageContent = actionNode.path(MESSAGE_CONTENT).asText(StringUtils.EMPTY);
+
+    if ((StringUtils.isEmpty(messageHeader)) && (StringUtils.isEmpty(messageContent))) {
+      String errorMessage = String.format("Fields {} and {} are empty.", MESSAGE_HEADER, MESSAGE_CONTENT);
+      throw new ZapierParserException(errorMessage);
+    }
 
     if (StringUtils.isNotEmpty(messageContent)) {
       messageContent = messageContent.replace("\n", MESSAGEML_LINEBREAK);

--- a/src/main/resources/metadata/metadataPostMessage.xml
+++ b/src/main/resources/metadata/metadataPostMessage.xml
@@ -2,9 +2,9 @@
 <metadata name="zapierPostMessage" type="com.symphony.integration.zapier.event.v2.postMessage" version="1.0">
 
     <object id="message" type="com.symphony.integration.zapier.event.message" version="1.0">
-        <field key="header" value="action_fields.message_header" blank="true" />
-        <field key="body" value="action_fields.message_content" blank="true" />
-        <field key="icon" value="action_fields.message_icon" blank="true" />
+        <field key="header" value="action_fields.message_header" />
+        <field key="body" value="action_fields.message_content" />
+        <field key="icon" value="action_fields.message_icon" />
     </object>
 
 </metadata>

--- a/src/main/resources/templates/templatePostMessage.xml
+++ b/src/main/resources/templates/templatePostMessage.xml
@@ -1,16 +1,20 @@
 <messageML>
     <div class="entity">
         <card class="barStyle">
-            <header>
-                <span>${entity['zapierPostMessage'].message.header}</span>
-            </header>
-            <body>
-                <div class="entity" data-entity-id="zapierPostMessage">
-                    <div class="labelBackground badge">
-                        <span>${entity['zapierPostMessage'].message.body}</span>
+            <#if (entity['zapierPostMessage'].message.header)??>
+                <header>
+                    <span>${entity['zapierPostMessage'].message.header}</span>
+                </header>
+            </#if>
+            <#if (entity['zapierPostMessage'].message.body)??>
+                <body>
+                    <div class="entity" data-entity-id="zapierPostMessage">
+                        <div class="labelBackground badge">
+                            <span>${entity['zapierPostMessage'].message.body}</span>
+                        </div>
                     </div>
-                </div>
-            </body>
+                </body>
+            </#if>
         </card>
     </div>
 </messageML>

--- a/src/test/java/org/symphonyoss/integration/webhook/zapier/parser/v1/ZapierPostMessageParserTest.java
+++ b/src/test/java/org/symphonyoss/integration/webhook/zapier/parser/v1/ZapierPostMessageParserTest.java
@@ -18,7 +18,6 @@ package org.symphonyoss.integration.webhook.zapier.parser.v1;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.symphonyoss.integration.webhook.zapier.ZapierEventConstants.POST_MESSAGE;
 import static org.symphonyoss.integration.webhook.zapier.ZapierEventConstants.ZAPIER_EVENT_TYPE_HEADER;
 
@@ -127,20 +126,20 @@ public class ZapierPostMessageParserTest {
     assertEquals(expected, result.getMessage());
   }
 
-  @Test
+  @Test(expected = ZapierParserException.class)
   public void testPostMessageNoHeaderNoContentWithIcon() throws IOException, WebHookParseException {
     String body = readFile("zapierNoHeaderNoContentWithIcon.json");
     WebHookPayload payload = new WebHookPayload(Collections.<String, String>emptyMap(), headers, body);
 
-    assertNull(parser.parse(payload));
+    parser.parse(payload);
   }
 
-  @Test
+  @Test(expected = ZapierParserException.class)
   public void testPostMessageNoHeaderNoContentNoIcon() throws IOException, WebHookParseException {
     String body = readFile("zapierNoHeaderNoContentNoIcon.json");
     WebHookPayload payload = new WebHookPayload(Collections.<String, String>emptyMap(), headers, body);
 
-    assertNull(parser.parse(payload));
+    parser.parse(payload);
   }
 
 }

--- a/src/test/java/org/symphonyoss/integration/webhook/zapier/parser/v2/V2ZapierPostMessageParserTest.java
+++ b/src/test/java/org/symphonyoss/integration/webhook/zapier/parser/v2/V2ZapierPostMessageParserTest.java
@@ -147,4 +147,23 @@ public class V2ZapierPostMessageParserTest {
     assertEquals(expectedEntityJson, result.getData());
   }
 
+  @Test(expected = ZapierParserException.class)
+  public void testPostMessageNoHeaderNoContentWithIcon() throws IOException, WebHookParseException {
+    parser.init();
+
+    String body = readFile("zapierNoHeaderNoContentWithIcon.json");
+    WebHookPayload payload = new WebHookPayload(Collections.<String, String>emptyMap(), headers, body);
+
+    parser.parse(payload);
+  }
+
+  @Test(expected = ZapierParserException.class)
+  public void testPostMessageNoHeaderNoContentNoIcon() throws IOException, WebHookParseException {
+    parser.init();
+
+    String body = readFile("zapierNoHeaderNoContentNoIcon.json");
+    WebHookPayload payload = new WebHookPayload(Collections.<String, String>emptyMap(), headers, body);
+
+    parser.parse(payload);
+  }
 }

--- a/src/test/resources/v2/entityJsonHeader.json
+++ b/src/test/resources/v2/entityJsonHeader.json
@@ -5,9 +5,7 @@
     "message" : {
       "type": "com.symphony.integration.zapier.event.message",
       "version": "1.0",
-      "header": "New Trello Card Created",
-      "body": "",
-      "icon": ""
+      "header": "New Trello Card Created"
     }
   }
 }

--- a/src/test/resources/v2/entityJsonHeaderContent.json
+++ b/src/test/resources/v2/entityJsonHeaderContent.json
@@ -6,8 +6,7 @@
       "type": "com.symphony.integration.zapier.event.message",
       "version": "1.0",
       "header": "New Trello Card Created",
-      "body": "<b>Card Name:</b> Card added for symphony innovate<br/><b>Card Link:</b> https://trello.com/c/8Md51YdW/15-card-added-for-symphony-innovate",
-      "icon": ""
+      "body": "<b>Card Name:</b> Card added for symphony innovate<br/><b>Card Link:</b> https://trello.com/c/8Md51YdW/15-card-added-for-symphony-innovate"
     }
   }
 }


### PR DESCRIPTION
If you send a Zapier JSON without header, content, and icon, the event is being rendered now on the Zapier with messageML V2.