### PR TITLE
Whitesource integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ target/
 node_modules/
 dist/
 npm-debug.log
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ addons:
     branch_pattern: "dev"
 
 script:
-- "if [[ \"$TRAVIS_PULL_REQUEST\" = \"false\" && $TRAVIS_BRANCH =~ dev ]]; then mvn clean deploy -Pversioneye -Pcobertura -DtransitiveDependencies=true --settings settings.xml ; fi"
+- "if [[ \"$TRAVIS_PULL_REQUEST\" = \"false\" && $TRAVIS_BRANCH =~ dev ]]; then mvn clean deploy -Pversioneye,whitesource -Pcobertura -DtransitiveDependencies=true --settings settings.xml ; fi"
 - "if [[ \"$TRAVIS_PULL_REQUEST\" != \"false\" ]]; then mvn clean package -Pcobertura; fi"
 
 after_success:

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>integration-zapier</artifactId>
 
     <properties>
+        <!-- This is temporary; set to true as soon as the WhiteSource dashboard is clean -->
         <whitesource.checkPolicies>false</whitesource.checkPolicies>
         <webapp.directory>zapier</webapp.directory>
         <rpm.name>zapier-symphony-integration</rpm.name>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>integration-zapier</artifactId>
 
     <properties>
+        <whitesource.checkPolicies>false</whitesource.checkPolicies>
         <webapp.directory>zapier</webapp.directory>
         <rpm.name>zapier-symphony-integration</rpm.name>
     </properties>


### PR DESCRIPTION
- Added support for WhiteSource dashboard
- Invited @campidelli and @ecarrenho-daitan to the WhiteSource dashboard (please let me know if you want to add other team members)
- Added `WHITESOURCE_TOKEN` to Travis Settings to run WhiteSource build profile: if any policy violation is found, the build breaks, otherwise, it submits the metrics remotely
- Temporary disabled build failure (search for `whitesource.checkPolicies` in  `pom.xml`)

To run the integration locally:

```
export WHITESOURCE_TOKEN=<token>
mvn clean install -Pwhitesource
```

Please note; this PR depends on a new Parent Pom version, therefore https://github.com/symphonyoss/App-Integrations-Commons/pull/120